### PR TITLE
Fix for Windows

### DIFF
--- a/sqlite_reverse_string.c
+++ b/sqlite_reverse_string.c
@@ -39,7 +39,7 @@ __declspec(dllexport)
 // UTF-8 stuff below taken from sqlite3 utf.c
 // #############################################################################
 
-static const unsigned char sqlite3Utf8Trans1[] = {
+const unsigned char sqlite3Utf8Trans1[] = {
   0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
   0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
   0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
@@ -160,6 +160,9 @@ static void string_reverse_implementation(sqlite3_context* ctx, int argc, sqlite
     sqlite3_result_text(ctx, result, -1, result_string_destructor);
 }
 
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
 int sqlite3_sqlitereversestring_init(
     sqlite3 *db,
     char **pzErrMsg,


### PR DESCRIPTION
With these changes I was able to compile and load this extension under windows. Perhaps the export at the top is not even necessary, in which case, the `static` can be restored.